### PR TITLE
[CSC-226] Quick order improvements in checkout

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "torq/shopwarecommon",
     "description": "torq/shopwarecommon",
     "type": "shopware-platform-plugin",
-    "version": "4.1.0",
+    "version": "4.2.0",
     "license": "MIT",
     "require": {
         "shopware/core": "^6.7.0",

--- a/src/Resources/snippet/quick-add.en-GB.json
+++ b/src/Resources/snippet/quick-add.en-GB.json
@@ -1,0 +1,9 @@
+{
+    "quickAdd": {
+        "sku": "SKU:",
+        "supplier": "Supplier:",
+        "quantity": "Quantity",
+        "addToCart": "Add to Cart",
+        "add": "Add"
+    }
+}

--- a/src/Resources/snippet/quick-add.fr-CA.json
+++ b/src/Resources/snippet/quick-add.fr-CA.json
@@ -1,0 +1,9 @@
+{
+    "quickAdd": {
+        "sku": "UGS:",
+        "supplier": "Fournisseur:",
+        "quantity": "Quantité",
+        "addToCart": "Ajouter au panier",
+        "add": "Ajouter"
+    }
+}

--- a/src/Resources/views/storefront/component/checkout/quick-add-autocomplete.html.twig
+++ b/src/Resources/views/storefront/component/checkout/quick-add-autocomplete.html.twig
@@ -10,7 +10,6 @@
         <form id="productDetailPageBuyProductForm" action="{{path('frontend.checkout.line-item.add')}}" method="post">
 
             {% block page_quick_add_autocomplete_form_hidden_fields %}
-            <input type="hidden" name="lineItems[{{ lineItemId }}][quantity]" value="1" aria-label="Quantity">
             <input type="hidden" name="redirectTo" value="frontend.checkout.cart.page">
             <input type="hidden" name="redirectParameters" data-redirect-parameters="true" value="{"productId":"{{ lineItemId }}"}" disabled="">
             <input type="hidden" name="lineItems[{{ lineItemId }}][id]" value="{{ lineItemId }}">
@@ -22,29 +21,43 @@
             {% endblock %}
 
             {% block page_quick_add_autocomplete_form_content %}
-                {% if advancedSearch %}                   
-                    <div class="row">
+                <div class="py-2 border-bottom">
+                    <div class="row align-items-center">
                         <div class="col-2">
                             {% if product.cover.media.url %}
-                                <img src="{{ product.cover.media.url }}" class="img-fluid" />
+                                <img src="{{ product.cover.media.url }}" class="img-fluid" alt="{{ product.translated.name }}" />
                             {% endif %}
                         </div>
-                        <div class="col-8">
-                            <div>{{ product.translated.name }}</div>
-                            <div>{{ product.calculatedPrice.unitPrice|currency }}</div>
-                            <div>{{ product.productNumber }}</div>
+                        <div class="col-6">
+                            <div class="font-weight-bold">{{ product.translated.name }}</div>
+                            <div class="text-muted small">{{ "quickAdd.sku"|trans }} {{ product.productNumber }}</div>
+                            {% if product.manufacturer %}
+                                <div class="text-muted small">{{ "quickAdd.supplier"|trans }} {{ product.manufacturer.translated.name }}</div>
+                            {% endif %}
+                            {% if product.options is not empty %}
+                                <div class="small mt-1">
+                                    {% for option in product.options %}
+                                        <span class="badge badge-light text-dark">{{ option.translated.name }}</span>
+                                    {% endfor %}
+                                </div>
+                            {% endif %}
                         </div>
                         <div class="col-2">
-                            <button class="btn text-left btn-quick-add-autocomplete" type="submit" title="Add to Cart" aria-label="Add to Cart">
-                                Add to Cart
+                            <input type="number"
+                                   class="form-control form-control-sm quick-add-quantity-input"
+                                   name="lineItems[{{ lineItemId }}][quantity]"
+                                   value="1"
+                                   min="1"
+                                   step="1"
+                                   aria-label="{{ "quickAdd.quantity"|trans }}">
+                        </div>
+                        <div class="col-2">
+                            <button class="btn btn-primary btn-sm btn-block btn-quick-add-autocomplete" type="submit" title="{{ "quickAdd.addToCart"|trans }}" aria-label="{{ "quickAdd.addToCart"|trans }}">
+                                {{ "quickAdd.add"|trans }}
                             </button>
                         </div>
                     </div>
-                {% else %}
-                    <button class="btn w-100 text-left btn-quick-add-autocomplete" type="submit" title="Add to Cart" aria-label="Add to Cart">
-                        {{product.productNumber}}
-                    </button>
-                {% endif %}
+                </div>
             {% endblock %}
         </form>
         {% endblock %}

--- a/src/Resources/views/storefront/page/checkout/cart/index.html.twig
+++ b/src/Resources/views/storefront/page/checkout/cart/index.html.twig
@@ -2,7 +2,11 @@
 
 {% block page_checkout_cart_add_product %}
     {% if config('TorqShopwareCommon.config.quickAddAutocompleteEnabled') === true %}
-        <div data-quick-add-autocomplete-plugin class="position-relative">
+        {% set urlPrefix = context.languageInfo.localeCode == 'fr-CA' ? '/fr/' : '/' %}
+        {% set dataQuickAddAutocompletePluginOptions = {
+            urlPrefix: urlPrefix
+        } %}
+        <div data-quick-add-autocomplete-plugin data-quick-add-autocomplete-plugin-options="{{ dataQuickAddAutocompletePluginOptions|json_encode }}" class="position-relative">
             {{ parent() }}
             <div id="quick-add-autocomplete-container" class="position-absolute w-100 z-3 overflow-auto" style="max-height:200px">
             </div>

--- a/src/Storefront/Controller/QuickAddController.php
+++ b/src/Storefront/Controller/QuickAddController.php
@@ -38,23 +38,26 @@ class QuickAddController extends StorefrontController
 
         $criteria = new Criteria();
         $criteria->setLimit(20);
-        $criteria->addFilter(new MultiFilter(
-            MultiFilter::CONNECTION_OR,
-            [
-                new EqualsFilter('childCount', 0),
-                new EqualsFilter('childCount', null),
-            ]
-        ));
+        $criteria->addAssociation('manufacturer');
+        $criteria->addAssociation('cover.media');
+        $criteria->addAssociation('options.group');
+        $criteria->addAssociation('children.options.group');
 
         if ($advancedSearchEnabled) {
             $searchRequest = clone $request;
             $searchRequest->query->set('search', $term);
             $products = $this->productSearchRoute->load($searchRequest, $context, $criteria)->getListingResult()->getEntities();
         } else {
-            $criteria->addFilter(new ContainsFilter('productNumber', $term));
+            $criteria->addFilter(new MultiFilter(
+                MultiFilter::CONNECTION_OR,
+                [
+                    new ContainsFilter('productNumber', $term),
+                    new ContainsFilter('name', $term),
+                ]
+            ));
             $products = $this->salesChannelProductRepository->search($criteria, $context)->getEntities();
         }
 
-        return $this->renderStorefront('@Storefront/storefront/component/checkout/quick-add-autocomplete.html.twig', ['products' => $products->getElements()]);
+        return $this->renderStorefront('@TorqShopwareCommon/storefront/component/checkout/quick-add-autocomplete.html.twig', ['products' => $products->getElements()]);
     }
 }


### PR DESCRIPTION
This PR includes Quick Order enhancements in the checkout page:
- Displaying the following product information:
  - SKU

  - Product name

  - Supplier/manufacturer

  - Options (for variants)

  - Quantity selector

- Products are searchable via advanced search (not only through product number), as can be configured in the "TorqShopwareCommon" through administration:

<img width="2134" height="822" alt="image" src="https://github.com/user-attachments/assets/a771a96b-d17c-4aa6-aeaa-693a2048d1d1" />

https://github.com/user-attachments/assets/e61e8a98-4a0c-44b8-8e35-f8fac32ac32f

